### PR TITLE
Retry hits failed with recoverable URL Errors

### DIFF
--- a/AEPAudience.podspec
+++ b/AEPAudience.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'AEPCore', '>= 5.0.0', '< 6.0.0'
   s.dependency 'AEPIdentity', '>= 5.0.0', '< 6.0.0'
-  s.dependency 'AEPServices', '>= 5.0.0', '< 6.0.0'
+  s.dependency 'AEPServices', '>= 5.1.0', '< 6.0.0'
 
   s.source_files          = 'AEPAudience/Sources/*.swift'
 

--- a/Package.swift
+++ b/Package.swift
@@ -20,11 +20,14 @@ let package = Package(
         .library(name: "AEPAudience", targets: ["AEPAudience"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "5.0.0"))
+        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "5.1.0"))
     ],
     targets: [
         .target(name: "AEPAudience",
-                dependencies: [.product(name: "AEPCore", package: "aepsdk-core-ios")],
+                dependencies: [
+                    .product(name: "AEPCore", package: "aepsdk-core-ios"),
+                    .product(name: "AEPServices", package: "aepsdk-core-ios"),
+                ],
                 path: "AEPAudience/Sources")
     ]
 )

--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ pod 'SwiftLint', '0.52.0'
 
 def core_pods
   pod 'AEPCore'
-  pod 'AEPServices'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.1.0'
   pod 'AEPRulesEngine'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ pod 'SwiftLint', '0.52.0'
 
 def core_pods
   pod 'AEPCore'
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.1.0'
+  pod 'AEPServices'
   pod 'AEPRulesEngine'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - AEPLifecycle (5.0.0):
     - AEPCore (< 6.0.0, >= 5.0.0)
   - AEPRulesEngine (5.0.0)
-  - AEPServices (5.0.0)
+  - AEPServices (5.1.0)
   - SwiftLint (0.52.0)
 
 DEPENDENCIES:
@@ -15,7 +15,7 @@ DEPENDENCIES:
   - AEPIdentity
   - AEPLifecycle
   - AEPRulesEngine
-  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v5.1.0`)
+  - AEPServices
   - SwiftLint (= 0.52.0)
 
 SPEC REPOS:
@@ -24,26 +24,17 @@ SPEC REPOS:
     - AEPIdentity
     - AEPLifecycle
     - AEPRulesEngine
+    - AEPServices
     - SwiftLint
-
-EXTERNAL SOURCES:
-  AEPServices:
-    :branch: dev-v5.1.0
-    :git: https://github.com/adobe/aepsdk-core-ios.git
-
-CHECKOUT OPTIONS:
-  AEPServices:
-    :commit: 53a2af15cf53dac950ff072bff7f0acd3b7012a4
-    :git: https://github.com/adobe/aepsdk-core-ios.git
 
 SPEC CHECKSUMS:
   AEPCore: f1c3e9238bb12e7e1103f4407c341ebc65aeab5b
   AEPIdentity: a65c1eba43a06f01b0dab191b27a53a81adada57
   AEPLifecycle: d4e0e1e86d6225d87203875d67f56c48f7ab7f67
   AEPRulesEngine: fe5800653a4bee07b1e41e61b4d5551f0dba557b
-  AEPServices: e42e5118128e81c0f797fdfb1dc9c4a714d644b8
+  AEPServices: c38b809c32336f10f773525e65c71a949abe54a7
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: d18074bc70f15ee06311673b019bee4f631815a0
+PODFILE CHECKSUM: 93674eb6bd266ce5c0635278c74cc8c849eb8608
 
 COCOAPODS: 1.13.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,7 +15,7 @@ DEPENDENCIES:
   - AEPIdentity
   - AEPLifecycle
   - AEPRulesEngine
-  - AEPServices
+  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v5.1.0`)
   - SwiftLint (= 0.52.0)
 
 SPEC REPOS:
@@ -24,8 +24,17 @@ SPEC REPOS:
     - AEPIdentity
     - AEPLifecycle
     - AEPRulesEngine
-    - AEPServices
     - SwiftLint
+
+EXTERNAL SOURCES:
+  AEPServices:
+    :branch: dev-v5.1.0
+    :git: https://github.com/adobe/aepsdk-core-ios.git
+
+CHECKOUT OPTIONS:
+  AEPServices:
+    :commit: 53a2af15cf53dac950ff072bff7f0acd3b7012a4
+    :git: https://github.com/adobe/aepsdk-core-ios.git
 
 SPEC CHECKSUMS:
   AEPCore: f1c3e9238bb12e7e1103f4407c341ebc65aeab5b
@@ -35,6 +44,6 @@ SPEC CHECKSUMS:
   AEPServices: e42e5118128e81c0f797fdfb1dc9c4a714d644b8
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: 93674eb6bd266ce5c0635278c74cc8c849eb8608
+PODFILE CHECKSUM: d18074bc70f15ee06311673b019bee4f631815a0
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.13.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

![Screenshot 2024-05-15 at 1 18 33 PM](https://github.com/adobe/aepsdk-edge-ios/assets/4697559/1db5c91e-3610-46cc-b919-3ba546ab9a32)

- Added logic to retry hits failed with a recoverable URLError, which were previously discarded.
- Added tests.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
